### PR TITLE
Fix deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,24 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
-    
+
     - name: Install dependencies
       run: npm ci
-    
+
     - name: Build
       run: npm run build
       env:
         CI: false # This prevents treating warnings as errors
-    
+
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-files
         path: build/
@@ -41,7 +41,7 @@ jobs:
     
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: build-files
         path: build


### PR DESCRIPTION
Updates all GitHub Actions to their latest versions to fix workflow failures:
- actions/checkout: v3 → v4
- actions/setup-node: v3 → v4
- actions/upload-artifact: v3 → v4 (was causing failure)
- actions/download-artifact: v3 → v4 (was causing failure)

The v3 artifact actions were deprecated on April 16, 2024 and are no longer supported. This update resolves the error:
"This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3"

All actions now use the latest stable versions for improved security and features.

🚀 Generated with [Claude Code](https://claude.com/claude-code)