### PR TITLE
Add XP rewards for reactions and shares

### DIFF
--- a/src/context/GamificationContext.js
+++ b/src/context/GamificationContext.js
@@ -43,6 +43,8 @@ export const XP_ACTIONS = {
   // Social
   FOLLOW_USER: 2,
   GAIN_FOLLOWER: 5,
+  ADD_REACTION: 3,
+  SHARE_POST: 8,
   JOIN_GROUP: 5,
   ATTEND_EVENT: 10,
   SEND_MESSAGE: 1,


### PR DESCRIPTION
## Summary
- add XP mapping entries so reacting to or sharing a post grants XP

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d137dc7e88323ab1f1e08c3ba9d4c)