### PR TITLE
Add dedicated notifications page and route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,7 @@ import CoursePlayer from './pages/courses/CoursePlayer';
 import Leaderboard from './pages/Leaderboard';
 import Settings from './pages/Settings';
 import NotFound from './pages/NotFound';
+import Notifications from './pages/Notifications';
 
 // Protected Route Component
 const ProtectedRoute = ({ children }) => {
@@ -131,6 +132,12 @@ function App() {
                 <Route path="/courses/:courseId" element={<CourseDetail />} />
 
                 <Route path="/leaderboard" element={<Leaderboard />} />
+
+                <Route path="/notifications" element={
+                  <ProtectedRoute>
+                    <Notifications />
+                  </ProtectedRoute>
+                } />
 
                 <Route path="/settings" element={
                   <ProtectedRoute>

--- a/src/components/notifications/NotificationCenter.js
+++ b/src/components/notifications/NotificationCenter.js
@@ -17,6 +17,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import NotificationItem from './NotificationItem';
 import { badgePulse } from '../../theme/animations';
+import { getMockNotifications } from '../../data/mockNotifications';
 
 /**
  * Notification Center component
@@ -38,93 +39,7 @@ const NotificationCenter = () => {
 
     // Simulate API call with setTimeout
     setTimeout(() => {
-      const mockNotifications = [
-        {
-          id: 1,
-          type: 'like',
-          user: {
-            id: 101,
-            name: 'Sarah Chen',
-            username: 'sarah_chen',
-            avatar_url: 'https://i.pravatar.cc/150?img=1'
-          },
-          message: 'Sarah Chen liked your post',
-          postId: 123,
-          timestamp: new Date(Date.now() - 1000 * 60 * 5), // 5 minutes ago
-          read: false
-        },
-        {
-          id: 2,
-          type: 'comment',
-          user: {
-            id: 102,
-            name: 'Marcus Johnson',
-            username: 'marcus_j',
-            avatar_url: 'https://i.pravatar.cc/150?img=2'
-          },
-          message: 'Marcus Johnson commented on your post',
-          postId: 123,
-          timestamp: new Date(Date.now() - 1000 * 60 * 30), // 30 minutes ago
-          read: false
-        },
-        {
-          id: 3,
-          type: 'follow',
-          user: {
-            id: 103,
-            name: 'Emily Rodriguez',
-            username: 'emily_r',
-            avatar_url: 'https://i.pravatar.cc/150?img=3'
-          },
-          message: 'Emily Rodriguez started following you',
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2), // 2 hours ago
-          read: false
-        },
-        {
-          id: 4,
-          type: 'group_invite',
-          user: {
-            id: 104,
-            name: 'David Park',
-            username: 'david_park',
-            avatar_url: 'https://i.pravatar.cc/150?img=4'
-          },
-          message: 'David Park invited you to join Psychedelic Research Group',
-          groupId: 5,
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 5), // 5 hours ago
-          read: true
-        },
-        {
-          id: 5,
-          type: 'event_reminder',
-          user: {
-            id: 105,
-            name: 'GSAPS',
-            username: 'gsaps_official',
-            avatar_url: 'https://i.pravatar.cc/150?img=5'
-          },
-          message: 'Reminder: Monthly Meetup starts in 1 hour',
-          eventId: 10,
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
-          read: true
-        },
-        {
-          id: 6,
-          type: 'like',
-          user: {
-            id: 106,
-            name: 'Lisa Wang',
-            username: 'lisa_wang',
-            avatar_url: 'https://i.pravatar.cc/150?img=6'
-          },
-          message: 'Lisa Wang and 3 others liked your comment',
-          postId: 125,
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2), // 2 days ago
-          read: true
-        }
-      ];
-
-      setNotifications(mockNotifications);
+      setNotifications(getMockNotifications());
       setLoading(false);
     }, 500);
   };
@@ -159,7 +74,6 @@ const NotificationCenter = () => {
 
   const handleViewAll = () => {
     handleClose();
-    // TODO: Navigate to full notifications page when implemented
     navigate('/notifications');
   };
 

--- a/src/data/mockNotifications.js
+++ b/src/data/mockNotifications.js
@@ -1,0 +1,140 @@
+export const getMockNotifications = () => ([
+  {
+    id: 1,
+    type: 'like',
+    user: {
+      id: 101,
+      name: 'Sarah Chen',
+      username: 'sarah_chen',
+      avatar_url: 'https://i.pravatar.cc/150?img=1'
+    },
+    message: 'Sarah Chen liked your post',
+    postId: 123,
+    timestamp: new Date(Date.now() - 1000 * 60 * 5),
+    read: false
+  },
+  {
+    id: 2,
+    type: 'comment',
+    user: {
+      id: 102,
+      name: 'Marcus Johnson',
+      username: 'marcus_j',
+      avatar_url: 'https://i.pravatar.cc/150?img=2'
+    },
+    message: 'Marcus Johnson commented on your post',
+    postId: 123,
+    timestamp: new Date(Date.now() - 1000 * 60 * 30),
+    read: false
+  },
+  {
+    id: 3,
+    type: 'follow',
+    user: {
+      id: 103,
+      name: 'Emily Rodriguez',
+      username: 'emily_r',
+      avatar_url: 'https://i.pravatar.cc/150?img=3'
+    },
+    message: 'Emily Rodriguez started following you',
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2),
+    read: false
+  },
+  {
+    id: 4,
+    type: 'group_invite',
+    user: {
+      id: 104,
+      name: 'David Park',
+      username: 'david_park',
+      avatar_url: 'https://i.pravatar.cc/150?img=4'
+    },
+    message: 'David Park invited you to join Psychedelic Research Group',
+    groupId: 5,
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 5),
+    read: true
+  },
+  {
+    id: 5,
+    type: 'event_reminder',
+    user: {
+      id: 105,
+      name: 'GSAPS',
+      username: 'gsaps_official',
+      avatar_url: 'https://i.pravatar.cc/150?img=5'
+    },
+    message: 'Reminder: Monthly Meetup starts in 1 hour',
+    eventId: 10,
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    read: true
+  },
+  {
+    id: 6,
+    type: 'like',
+    user: {
+      id: 106,
+      name: 'Lisa Wang',
+      username: 'lisa_wang',
+      avatar_url: 'https://i.pravatar.cc/150?img=6'
+    },
+    message: 'Lisa Wang and 3 others liked your comment',
+    postId: 125,
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2),
+    read: true
+  },
+  {
+    id: 7,
+    type: 'comment',
+    user: {
+      id: 107,
+      name: 'Michael Brown',
+      username: 'michael_brown',
+      avatar_url: 'https://i.pravatar.cc/150?img=7'
+    },
+    message: 'Michael Brown mentioned you in a comment',
+    postId: 130,
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
+    read: true
+  },
+  {
+    id: 8,
+    type: 'follow',
+    user: {
+      id: 108,
+      name: 'Natalie Kim',
+      username: 'natalie_kim',
+      avatar_url: 'https://i.pravatar.cc/150?img=8'
+    },
+    message: 'Natalie Kim started following you',
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5),
+    read: true
+  },
+  {
+    id: 9,
+    type: 'group_invite',
+    user: {
+      id: 109,
+      name: 'Psychedelic Therapists',
+      username: 'psychedelic_therapists',
+      avatar_url: 'https://i.pravatar.cc/150?img=9'
+    },
+    message: 'New discussion in Psychedelic Therapists group',
+    groupId: 7,
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
+    read: true
+  },
+  {
+    id: 10,
+    type: 'event_reminder',
+    user: {
+      id: 110,
+      name: 'GSAPS Events',
+      username: 'gsaps_events',
+      avatar_url: 'https://i.pravatar.cc/150?img=10'
+    },
+    message: 'Workshop: Integrative Approaches starts tomorrow',
+    eventId: 12,
+    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 10),
+    read: true
+  }
+]);

--- a/src/pages/Notifications.js
+++ b/src/pages/Notifications.js
@@ -1,0 +1,144 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  List,
+  Divider,
+  Stack,
+  ToggleButtonGroup,
+  ToggleButton,
+  Button,
+  Chip
+} from '@mui/material';
+import { CheckCircle as CheckIcon } from '@mui/icons-material';
+import NotificationItem from '../components/notifications/NotificationItem';
+import { getMockNotifications } from '../data/mockNotifications';
+
+const Notifications = () => {
+  const [notifications, setNotifications] = useState([]);
+  const [filter, setFilter] = useState('all');
+
+  useEffect(() => {
+    setNotifications(getMockNotifications());
+  }, []);
+
+  const handleFilterChange = (_, newFilter) => {
+    if (newFilter !== null) {
+      setFilter(newFilter);
+    }
+  };
+
+  const handleMarkAsRead = (notificationId) => {
+    setNotifications(prev =>
+      prev.map(notification =>
+        notification.id === notificationId
+          ? { ...notification, read: true }
+          : notification
+      )
+    );
+  };
+
+  const handleMarkAllAsRead = () => {
+    setNotifications(prev => prev.map(notification => ({ ...notification, read: true })));
+  };
+
+  const handleDeleteNotification = (notificationId) => {
+    setNotifications(prev => prev.filter(notification => notification.id !== notificationId));
+  };
+
+  const filteredNotifications = useMemo(() => {
+    switch (filter) {
+      case 'unread':
+        return notifications.filter(notification => !notification.read);
+      case 'read':
+        return notifications.filter(notification => notification.read);
+      default:
+        return notifications;
+    }
+  }, [filter, notifications]);
+
+  return (
+    <Box sx={{ py: { xs: 2, sm: 3 } }}>
+      <Stack spacing={2}>
+        <Box>
+          <Typography variant="h4" fontWeight={700} gutterBottom>
+            Notifications
+          </Typography>
+          <Typography color="text.secondary">
+            Stay up to date with activity across your GSAPS network.
+          </Typography>
+        </Box>
+
+        <Paper elevation={0} sx={{ p: 2, borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={2}
+            justifyContent="space-between"
+            alignItems={{ xs: 'flex-start', sm: 'center' }}
+          >
+            <ToggleButtonGroup
+              value={filter}
+              exclusive
+              onChange={handleFilterChange}
+              size="small"
+            >
+              <ToggleButton value="all">All</ToggleButton>
+              <ToggleButton value="unread">Unread</ToggleButton>
+              <ToggleButton value="read">Read</ToggleButton>
+            </ToggleButtonGroup>
+
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Chip label={`${notifications.filter(n => !n.read).length} unread`} color="error" variant="outlined" />
+              <Button
+                size="small"
+                startIcon={<CheckIcon />}
+                onClick={handleMarkAllAsRead}
+                disabled={notifications.every(n => n.read)}
+              >
+                Mark all read
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+
+        <Paper elevation={0} sx={{ borderRadius: 3, border: '1px solid', borderColor: 'divider' }}>
+          {filteredNotifications.length === 0 ? (
+            <Box sx={{ textAlign: 'center', py: 8, px: 4 }}>
+              <Typography variant="h6" gutterBottom>
+                {filter === 'unread' ? 'You are all caught up!' : 'No notifications yet'}
+              </Typography>
+              <Typography color="text.secondary">
+                {filter === 'unread'
+                  ? 'We will let you know when something new happens.'
+                  : 'Engage with the community to start receiving updates.'}
+              </Typography>
+            </Box>
+          ) : (
+            <>
+              <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Showing {filteredNotifications.length} notification{filteredNotifications.length !== 1 ? 's' : ''}
+                </Typography>
+              </Box>
+              <List sx={{ p: 0 }}>
+                {filteredNotifications.map(notification => (
+                  <React.Fragment key={notification.id}>
+                    <NotificationItem
+                      notification={notification}
+                      onRead={handleMarkAsRead}
+                      onDelete={handleDeleteNotification}
+                    />
+                    <Divider component="li" />
+                  </React.Fragment>
+                ))}
+              </List>
+            </>
+          )}
+        </Paper>
+      </Stack>
+    </Box>
+  );
+};
+
+export default Notifications;


### PR DESCRIPTION
## Summary
- add a reusable mock notification generator so the bell dropdown and new page share consistent sample data
- create a `/notifications` page with filtering, bulk actions, and reuse of the existing NotificationItem UI, and gate the route with auth
- wire the "See all notifications" button to the new protected route to avoid dead navigation

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b70dbad088323a3b5d4f34c1ed9ad)