### PR TITLE
Add missing page imports to app routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,14 +23,20 @@ import Events from './pages/Events';
 import EventDetail from './pages/EventDetail';
 import Messages from './pages/Messages';
 import Conversation from './pages/Conversation';
+import PasswordReset from './pages/PasswordReset';
+import VerifyEmail from './pages/VerifyEmail';
 import ResearchLibrary from './pages/library/ResearchLibrary';
 import PaperDetail from './pages/library/PaperDetail';
 import Courses from './pages/courses/Courses';
 import CourseDetail from './pages/courses/CourseDetail';
 import CoursePlayer from './pages/courses/CoursePlayer';
+import ResearchWorkspace from './pages/workspaces/ResearchWorkspace';
+import SubscriptionBilling from './pages/billing/SubscriptionBilling';
+import OrgReporting from './pages/admin/OrgReporting';
 import Leaderboard from './pages/Leaderboard';
 import Settings from './pages/Settings';
 import NotFound from './pages/NotFound';
+import AdminDashboard from './pages/AdminDashboard';
 
 // Protected Route Component
 const ProtectedRoute = ({ children }) => {


### PR DESCRIPTION
## Summary
- add explicit imports for reset, verify, workspace, billing, reporting, and admin dashboard pages in the main app router

## Testing
- npm test -- --watch=false *(fails: react-scripts test cannot parse ESM import from marked in ResearchWorkspace)*
- npm run lint *(fails: existing lint errors and warnings in multiple files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ad0d88e483239be7937b6a51dec1)