### PR TITLE
Implement cookie-based authentication flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9245,6 +9245,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/engine.io-client": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
@@ -16355,6 +16365,13 @@
         "node": ">= 20"
       }
     },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -20563,6 +20580,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/socket.io-client": {

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,8 @@ import Home from './pages/Home';
 import Feed from './pages/Feed';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import PasswordReset from './pages/PasswordReset';
+import VerifyEmail from './pages/VerifyEmail';
 import UserProfile from './pages/UserProfile';
 import Members from './pages/Members';
 import Groups from './pages/Groups';
@@ -25,11 +27,15 @@ import Messages from './pages/Messages';
 import Conversation from './pages/Conversation';
 import ResearchLibrary from './pages/library/ResearchLibrary';
 import PaperDetail from './pages/library/PaperDetail';
+import ResearchWorkspace from './pages/workspaces/ResearchWorkspace';
 import Courses from './pages/courses/Courses';
 import CourseDetail from './pages/courses/CourseDetail';
 import CoursePlayer from './pages/courses/CoursePlayer';
 import Leaderboard from './pages/Leaderboard';
 import Settings from './pages/Settings';
+import SubscriptionBilling from './pages/billing/SubscriptionBilling';
+import OrgReporting from './pages/admin/OrgReporting';
+import AdminDashboard from './pages/AdminDashboard';
 import NotFound from './pages/NotFound';
 
 // Protected Route Component

--- a/src/__tests__/a11y.test.js
+++ b/src/__tests__/a11y.test.js
@@ -8,6 +8,7 @@ import { ThemeProvider } from '../context/ThemeContext';
 import { GamificationProvider } from '../context/GamificationContext';
 import { ToastProvider } from '../components/common/Toast';
 import { AccessibilityProvider } from '../context/AccessibilityContext';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 jest.mock('axios', () => ({
   create: () => ({
@@ -20,23 +21,27 @@ jest.mock('axios', () => ({
   }),
 }));
 
+jest.mock('../pages/workspaces/ResearchWorkspace', () => () => <div>ResearchWorkspace</div>);
+
 describe('Accessibility smoke test', () => {
   expect.extend(toHaveNoViolations);
 
   const renderApp = () =>
     render(
       <BrowserRouter>
-        <AuthProvider>
-          <GamificationProvider>
-            <ThemeProvider>
-              <AccessibilityProvider>
-                <ToastProvider>
-                  <App />
-                </ToastProvider>
-              </AccessibilityProvider>
-            </ThemeProvider>
-          </GamificationProvider>
-        </AuthProvider>
+        <QueryClientProvider client={new QueryClient()}>
+          <AuthProvider>
+            <GamificationProvider>
+              <ThemeProvider>
+                <AccessibilityProvider>
+                  <ToastProvider>
+                    <App />
+                  </ToastProvider>
+                </AccessibilityProvider>
+              </ThemeProvider>
+            </GamificationProvider>
+          </AuthProvider>
+        </QueryClientProvider>
       </BrowserRouter>
     );
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,20 +1,22 @@
+import api from './api';
 import { login, register, getCurrentUser as fetchCurrentUser } from './backend';
 
 export const loginUser = async (username, password) => {
-  const { token, user } = await login(username, password);
-  localStorage.setItem('gsaps_token', token);
+  const { user } = await login(username, password);
   return user;
 };
 
 export const registerUser = async (userData) => {
-  const { token, user } = await register(userData);
-  localStorage.setItem('gsaps_token', token);
+  const { user } = await register(userData);
   return user;
 };
 
 export const logoutUser = async () => {
-  localStorage.removeItem('gsaps_token');
-  localStorage.removeItem('gsaps_refresh_token');
+  try {
+    await api.post('/auth/logout');
+  } catch (error) {
+    // Best-effort logout; ignore errors to allow UI state to clear
+  }
   return { success: true };
 };
 


### PR DESCRIPTION
## Summary
- switch API client and auth utilities to rely on HTTP-only cookie tokens with automatic refresh support
- hydrate authentication state from protected endpoints and handle silent session expiry in the auth context
- update accessibility test harness and missing imports to align with the new authentication flow

## Testing
- CI=true npm test -- --watch=false
- npm run lint *(fails: existing warnings/errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ad0dfde4832398bd136b0a6366a4)