### PR TITLE
docs: add preview guide and mock auth fallbacks

### DIFF
--- a/docs/core/getting-started/PREVIEW_SESSION.md
+++ b/docs/core/getting-started/PREVIEW_SESSION.md
@@ -1,0 +1,31 @@
+# Local Preview Session (Static Build)
+
+Use this walkthrough to spin up a shareable preview of the GSAPS Social Media App from the optimized production build.
+
+## Prerequisites
+- Node.js 14+
+- npm 6+
+- Ports 3000/host networking available
+
+## Steps
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Build the production bundle
+   ```bash
+   npm run build
+   ```
+3. Serve the static build locally
+   ```bash
+   npx serve -s build -l 3000
+   ```
+4. Open the app at `http://localhost:3000` (or forwarded port in your environment).
+
+## Demo credentials
+```
+Username: demo_user
+Password: demo123
+```
+
+The experience runs fully offline with mock data; clearing browser storage resets demo state.

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,6 +1,23 @@
 import api from './api';
 import { login, register, getCurrentUser as fetchCurrentUser } from './backend';
 
+const MOCK_SESSIONS = [
+  {
+    id: 'sess-current',
+    device: 'Chrome on macOS',
+    location: 'San Francisco, US',
+    lastActive: new Date().toISOString(),
+    current: true
+  },
+  {
+    id: 'sess-remote',
+    device: 'Firefox on Linux',
+    location: 'Toronto, CA',
+    lastActive: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+    current: false
+  }
+];
+
 export const loginUser = async (username, password) => {
   const { user } = await login(username, password);
   return user;
@@ -22,4 +39,44 @@ export const logoutUser = async () => {
 
 export const getCurrentUser = async () => {
   return fetchCurrentUser();
+};
+
+export const requestPasswordReset = async (email) => {
+  return {
+    success: true,
+    email,
+    token: 'mock-reset-token'
+  };
+};
+
+export const resetPassword = async () => {
+  return { success: true };
+};
+
+export const getSessions = async () => {
+  return MOCK_SESSIONS;
+};
+
+export const enableMfa = async () => {
+  return {
+    recoveryCodes: ['4YK7J', '9PA2L', 'C7M3B', 'D2Q9Z', 'J5X1T']
+  };
+};
+
+export const disableMfa = async () => {
+  return { success: true };
+};
+
+export const revokeSession = async () => {
+  return { success: true };
+};
+
+export const requestEmailVerification = async () => {
+  return {
+    token: 'mock-verification-token'
+  };
+};
+
+export const verifyEmailToken = async () => {
+  return { success: true };
 };

--- a/src/context/GamificationContext.js
+++ b/src/context/GamificationContext.js
@@ -20,6 +20,16 @@ export const XP_ACTIONS = {
   UPLOAD_PAPER: 50
 };
 
+export const RANKS = {
+  1: { name: 'Novice', color: '#8bd3e6', icon: '🌱' },
+  5: { name: 'Explorer', color: '#9fa8da', icon: '🧭' },
+  10: { name: 'Scholar', color: '#f6c177', icon: '📚' },
+  15: { name: 'Contributor', color: '#81c784', icon: '🤝' },
+  20: { name: 'Mentor', color: '#ffb74d', icon: '🧠' },
+  30: { name: 'Luminary', color: '#ba68c8', icon: '✨' },
+  40: { name: 'Mythic', color: '#ef5350', icon: '🛡️' }
+};
+
 const LEVEL_THRESHOLDS = [0, 100, 250, 500, 850, 1300];
 
 const calculateLevel = (xp) => {
@@ -75,7 +85,7 @@ export const GamificationProvider = ({ children }) => {
       updateStat: () => {},
       recentXP: []
     }),
-    [userStats, isLoading]
+    [awardXP, userStats, isLoading]
   );
 
   return <GamificationContext.Provider value={value}>{children}</GamificationContext.Provider>;

--- a/src/pages/Feed.js
+++ b/src/pages/Feed.js
@@ -1,15 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import {
-  Alert,
-  Box,
-  Container,
-  Typography,
-  Fab,
-  useTheme,
-  useMediaQuery,
-  CircularProgress,
-  Button
-} from '@mui/material';
+import { Box, Container, Typography, Fab, useTheme, useMediaQuery, CircularProgress } from '@mui/material';
 import { Add as AddIcon } from '@mui/icons-material';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import PostCard from '../components/feed/PostCard';
@@ -18,6 +8,7 @@ import { fadeInUp } from '../theme/animations';
 import { useGamification } from '../context/GamificationContext';
 import { useAuth } from '../context/AuthContext';
 import { createPost, deletePost, fetchPosts, reactToPost } from '../api/backend';
+import GuidelinesGate from '../components/moderation/GuidelinesGate';
 
 const Feed = () => {
   const theme = useTheme();
@@ -30,6 +21,22 @@ const Feed = () => {
     queryFn: fetchPosts
   });
   const [composerOpen, setComposerOpen] = useState(false);
+  const [guidelinesOpen, setGuidelinesOpen] = useState(true);
+  const communityGuidelines = useMemo(
+    () => ({
+      version: '1.3',
+      lastUpdated: 'Mar 14, 2024',
+      summary: 'Safety-first moderation with human review for sensitive research topics.',
+      items: [
+        'No unverified medical advice or sourcing requests.',
+        'Use content warnings for challenging experiences and images.',
+        'Respect anonymity and never dox participants.',
+        'Cite sources when discussing published research.',
+        'Report safety issues immediately to moderators.'
+      ]
+    }),
+    []
+  );
 
   const createPostMutation = useMutation({
     mutationFn: createPost,
@@ -117,6 +124,10 @@ const Feed = () => {
     },
     [awardXP, updateStat]
   );
+
+  const handleAcceptGuidelines = () => {
+    setGuidelinesOpen(false);
+  };
 
   const handleDelete = useCallback(
     (postId) => {

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -41,7 +41,6 @@ import { enableMfa, disableMfa, getSessions, revokeSession, requestEmailVerifica
 const Settings = () => {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
-  const { preferences, togglePreference } = useAccessibility();
   const [activeTab, setActiveTab] = useState(0);
   const [showPassword, setShowPassword] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');

--- a/src/pages/courses/Courses.js
+++ b/src/pages/courses/Courses.js
@@ -29,6 +29,7 @@ import { fetchCourses } from '../../api/backend';
 import CourseCard from '../../components/courses/CourseCard';
 import CreateCourseDialog from '../../components/courses/CreateCourseDialog';
 import { fadeInUp } from '../../theme/animations';
+import { useExperiment } from '../../utils/recommendationService';
 
 const Courses = () => {
   const [viewMode, setViewMode] = useState('grid');
@@ -37,8 +38,7 @@ const Courses = () => {
   const [filterLevel, setFilterLevel] = useState('all');
   const [sortBy, setSortBy] = useState('recent');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [recommendedCourses, setRecommendedCourses] = useState([]);
-  const courseVariant = useExperiment('course-feed', ['control', 'personalized']);
+  useExperiment('course-feed', ['control', 'personalized']);
 
   const { data: courses = [], isLoading } = useQuery({ queryKey: ['courses'], queryFn: fetchCourses });
 

--- a/src/pages/library/ResearchLibrary.js
+++ b/src/pages/library/ResearchLibrary.js
@@ -23,6 +23,7 @@ import PaperUploadDialog from '../../components/library/PaperUploadDialog';
 import { useToast } from '../../components/common';
 import { useGamification } from '../../context/GamificationContext';
 import { createResearchAsset, fetchResearchAssets } from '../../api/backend';
+import { useExperiment } from '../../utils/recommendationService';
 
 const ResearchLibrary = () => {
   const toast = useToast();
@@ -34,8 +35,7 @@ const ResearchLibrary = () => {
   const [sortBy, setSortBy] = useState('recent');
   const [viewMode, setViewMode] = useState('grid');
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
-  const [recommendedPapers, setRecommendedPapers] = useState([]);
-  const recommendationVariant = useExperiment('library-feed', ['control', 'personalized']);
+  useExperiment('library-feed', ['control', 'personalized']);
 
   const { data: papers = [], isLoading } = useQuery({ queryKey: ['research-assets'], queryFn: fetchResearchAssets });
 
@@ -84,12 +84,6 @@ const ResearchLibrary = () => {
       type: payload.topic || 'paper'
     });
   };
-
-  const relatedTopics = useMemo(() => {
-    const topics = new Set();
-    recommendedPapers.forEach(paper => paper.topics?.forEach(topic => topics.add(topic)));
-    return Array.from(topics).slice(0, 6);
-  }, [recommendedPapers]);
 
   return (
     <Box sx={{ bgcolor: 'background.default', minHeight: '100vh', py: 4 }}>


### PR DESCRIPTION
Codex task: Create an in-container preview experience and restore missing mocks for auth flows
Original request: Create a preview of the app for me to see and use here

## Summary
- add missing mock auth helpers for password resets, MFA, sessions, and verification flows used by settings screens
- restore gamification rank constants and feed guidelines gate while cleaning unused experiment hooks
- document how to build and serve a static local preview with demo credentials

## Testing
- npm run build (warnings only from existing lint notices)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b6dcf3388323908c698a1ac03df5)